### PR TITLE
fix(README.md): provide correct project links for license and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Please refer to the Extend Reality [Code of Conduct].
 
 Code released under the [MIT License][License].
 
-[License-Badge]: https://img.shields.io/github/license/ExtendRealityLtd/Tilia.Utilities.ObjectStateSwitcher.Unity.svg
-[Version-Release]: https://img.shields.io/github/release/ExtendRealityLtd/Tilia.Utilities.ObjectStateSwitcher.Unity.svg
+[License-Badge]: https://img.shields.io/github/license/ExtendRealityLtd/Tilia.Utilities.Shaders.Unity.svg
+[Version-Release]: https://img.shields.io/github/release/ExtendRealityLtd/Tilia.Utilities.Shaders.Unity.svg
 [project coding conventions]: https://github.com/ExtendRealityLtd/.github/blob/master/CONVENTIONS/UNITY3D.md
 
 [Tilia-Image]: https://user-images.githubusercontent.com/1029673/67681496-5bf10700-f985-11e9-9413-e61801b6eab5.png


### PR DESCRIPTION
The project link was incorrect for the License badge and the version
release so it was showing the incorrect data on the README. This has
now been updated to the correct project link.