### PR TITLE
feat(Screen): screen overlay shader for crosshair

### DIFF
--- a/Runtime/Shaders/Screen_Overlay.shader
+++ b/Runtime/Shaders/Screen_Overlay.shader
@@ -1,0 +1,62 @@
+﻿// UNITY_SHADER_NO_UPGRADE
+Shader "Tilia/Screen/Overlay"
+{
+	Properties
+	{
+		_Color("Color Tint", Color) = (1,1,1,1)
+		_MainTex("Base (RGB) Alpha (A)", 2D) = "white"
+	}
+
+		SubShader
+	{
+		Lighting Off
+		ZTest Off
+		Cull back
+		Blend SrcAlpha OneMinusSrcAlpha
+		Tags{ Queue = Transparent }
+
+		Pass
+		{
+			CGPROGRAM
+				#pragma vertex vert
+				#pragma fragment frag
+
+				#include "UnityCG.cginc"
+
+				struct data
+				{
+					float4 pos : POSITION;
+					float2 coord : TEXCOORD0;
+					fixed4 color : COLOR;
+				};
+
+				struct vert2frag
+				{
+					float4 pos : SV_POSITION;
+					half2 coord : TEXCOORD0;
+					fixed4 color : COLOR;
+				};
+
+				sampler2D _MainTex;
+				float4 _MainTex_ST;
+				fixed4 _Color;
+
+				vert2frag vert(data input)
+				{
+					vert2frag result;
+					result.pos = UnityObjectToClipPos(input.pos);
+					result.pos.z -= 0.01;
+					result.coord = TRANSFORM_TEX(input.coord, _MainTex);
+					result.color = input.color;
+					return result;
+				}
+
+				fixed4 frag(vert2frag input) : COLOR
+				{
+					fixed4 result = tex2D(_MainTex, input.coord) * input.color * _Color;
+					return result;
+				}
+			ENDCG
+		}
+	}
+}

--- a/Runtime/Shaders/Screen_Overlay.shader.meta
+++ b/Runtime/Shaders/Screen_Overlay.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 0e2fe2dff6de31b4dbf8e179001f2e89
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The Screen Overlay shader draws over everything else in the scene
but draws within the world space so can be used as a 3d crosshair
that will draw over any object it is pointing at.