### PR TITLE
feat(Unlit): add transparent color shader that blocks out complete view

### DIFF
--- a/Runtime/Shaders/Unlit_TransparentColorBlockout.shader
+++ b/Runtime/Shaders/Unlit_TransparentColorBlockout.shader
@@ -1,0 +1,19 @@
+﻿// UNITY_SHADER_NO_UPGRADE
+Shader "Tilia/Unlit/TransparentColorBlockout"
+{
+	Properties
+	{
+		_Color("Main Color", Color) = (1,1,1,1)
+	}
+
+		SubShader
+	{
+		Tags { "Queue" = "Transparent" "IgnoreProjector" = "True" "RenderType" = "Transparent" }
+		LOD 100
+		Fog { Mode Off }
+		ZTest Always
+		Blend SrcAlpha OneMinusSrcAlpha
+		Color[_Color]
+		Pass {}
+	}
+}

--- a/Runtime/Shaders/Unlit_TransparentColorBlockout.shader.meta
+++ b/Runtime/Shaders/Unlit_TransparentColorBlockout.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 81ca9e7bd24c68543937aa6b06f278bf
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The Unlit Transparent Color Blockout shader will completely block the
camera view with the color provided.