### PR TITLE
fix(Shaders): add support for single pass instanced rendering

### DIFF
--- a/Runtime/Shaders/Screen_Overlay.shader
+++ b/Runtime/Shaders/Screen_Overlay.shader
@@ -28,6 +28,8 @@ Shader "Tilia/Screen/Overlay"
 					float4 pos : POSITION;
 					float2 coord : TEXCOORD0;
 					fixed4 color : COLOR;
+
+					UNITY_VERTEX_INPUT_INSTANCE_ID
 				};
 
 				struct vert2frag
@@ -35,6 +37,8 @@ Shader "Tilia/Screen/Overlay"
 					float4 pos : SV_POSITION;
 					half2 coord : TEXCOORD0;
 					fixed4 color : COLOR;
+
+					UNITY_VERTEX_OUTPUT_STEREO
 				};
 
 				sampler2D _MainTex;
@@ -44,6 +48,11 @@ Shader "Tilia/Screen/Overlay"
 				vert2frag vert(data input)
 				{
 					vert2frag result;
+
+					UNITY_SETUP_INSTANCE_ID(input);
+					UNITY_INITIALIZE_OUTPUT(vert2frag, result);
+					UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(result);
+
 					result.pos = UnityObjectToClipPos(input.pos);
 					result.pos.z -= 0.01;
 					result.coord = TRANSFORM_TEX(input.coord, _MainTex);

--- a/Runtime/Shaders/UI_Overlay.shader
+++ b/Runtime/Shaders/UI_Overlay.shader
@@ -57,6 +57,8 @@ Shader "Tilia/UI/Overlay"
 				float4 vertex : POSITION;
 				float2 texcoord : TEXCOORD0;
 				float4 color : COLOR;
+
+				UNITY_VERTEX_INPUT_INSTANCE_ID
 			};
 
 			struct v2f
@@ -64,6 +66,8 @@ Shader "Tilia/UI/Overlay"
 				float4 vertex : SV_POSITION;
 				half2 texcoord : TEXCOORD0;
 				fixed4 color : COLOR;
+
+				UNITY_VERTEX_OUTPUT_STEREO
 			};
 
 			sampler2D _MainTex;
@@ -74,6 +78,11 @@ Shader "Tilia/UI/Overlay"
 			v2f vert(appdata_t v)
 			{
 				v2f o;
+
+				UNITY_SETUP_INSTANCE_ID(v);
+				UNITY_INITIALIZE_OUTPUT(v2f, o);
+				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
 				o.vertex = UnityObjectToClipPos(v.vertex);
 				o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
 				o.color = v.color * _Color;


### PR DESCRIPTION
A couple of the shaders were not working with single pass instanced
rendering and were only rendering the object in the left eye camera.

This has been fixed by following the guide in the Unity Documentation:
https://docs.unity3d.com/Manual/SinglePassInstancing.html